### PR TITLE
Metrics fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "synthius"
-version = "0.2.0"
+version = "0.3.0"
 description = "A toolkit for generating and evaluating synthetic data in terms of utility, privacy, and similarity"
 authors = ["Maryam Mohebi <maryam@mohebi.me>"]
 readme = "README.md"

--- a/synthius/metric/inference.py
+++ b/synthius/metric/inference.py
@@ -176,6 +176,12 @@ class InferenceMetric(AnonymeterMetric):
             synthetic_data = synthetic_data[~synthetic_data[self.secret].isna()]
             logging.warning("Training with %d samples.", synthetic_data.shape[0])
             predictor = TabularPredictor(label=self.secret)
+
+            for df in [synthetic_data, self.real_data, self.control_data]:
+                if df is not None and self.secret in df:
+                    if df[self.secret].dtype == bool:  # Autogluon is failing in this case, cast to int
+                        df.loc[:, self.secret] = df[self.secret].astype(int)
+
             predictor.fit(
                 train_data=synthetic_data,
                 hyperparameters={

--- a/synthius/metric/privacy_against_inference.py
+++ b/synthius/metric/privacy_against_inference.py
@@ -16,7 +16,7 @@ from sdmetrics.single_table import (
     CategoricalZeroCAP,
 )
 
-from synthius.metric.utils import BaseMetric, generate_metadata, load_data, preprocess_data
+from synthius.metric.utils import BaseMetric, generate_metadata, load_data, preprocess_data, apply_preprocessing
 
 logger = getLogger()
 
@@ -216,7 +216,7 @@ class PrivacyAgainstInference(BaseMetric):
         Returns:
             pd.DataFrame: Evaluation results for the model.
         """
-        synthetic_data = load_data(synthetic_data_path).copy()
+        synthetic_data = apply_preprocessing(synthetic_data_path, self.fill_values).copy()
         model_name = synthetic_data_path.stem
 
         results: dict[str, str | float] = {"Model Name": model_name}
@@ -232,7 +232,11 @@ class PrivacyAgainstInference(BaseMetric):
 
         for metric in self.selected_metrics or metric_dispatch.keys():
             if metric in metric_dispatch:
-                results[metric] = metric_dispatch[metric](synthetic_data)
+                try:
+                    results[metric] = metric_dispatch[metric](synthetic_data)
+                except Exception as e:
+                    logger.warning("Could not compute metric %s for model %s. Skipping.", metric, model_name)
+                    logger.warning(e)
                 logger.warning("%s for %s Done.", metric, model_name)
             else:
                 logger.warning("Metric %s is not supported and will be skipped.", metric)


### PR DESCRIPTION
Impute missing values to avoid (SDMetrics) model training exceptions;
Cast binary targets to int to avoid model (Autogluon) training exceptions;
Remove ID model training from the InferenceAttack;
Add the InferenceAttack dataframe to the final results.